### PR TITLE
Uses regional bucket name for origin

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudfront_distribution" "cdn" {
   origin {
     origin_id   = aws_s3_bucket.static_website.id
-    domain_name = aws_s3_bucket.static_website.bucket_domain_name
+    domain_name = aws_s3_bucket.static_website.bucket_regional_domain_name
   }
 
   aliases             = [var.url]


### PR DESCRIPTION
Minimises the time for the CloudFront distribution to reference S3 bucket, by referencing the regional bucket name for the origin property. Global DNS records for S3 buckets can take over an hour to propagate. The regional bucket name records are almost instant.  