### PR TITLE
Removes cdn caching of index.html and config.json

### DIFF
--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -42,6 +42,49 @@ resource "aws_cloudfront_distribution" "cdn" {
     max_ttl                = var.max_ttl
   }
 
+  ordered_cache_behavior {
+    allowed_methods        = ["GET", "HEAD" ]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+    default_ttl            = 0
+    max_ttl                = 0
+    min_ttl                = 0
+    path_pattern           = "index.html"
+    smooth_streaming       = false
+    target_origin_id       = aws_s3_bucket.static_website.id
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+        query_string = false
+
+    cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  ordered_cache_behavior {
+    allowed_methods        = ["GET", "HEAD" ]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+    default_ttl            = 0
+    max_ttl                = 0
+    min_ttl                = 0
+    path_pattern           = "config.json"
+    smooth_streaming       = false
+    target_origin_id       = aws_s3_bucket.static_website.id
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+        query_string = false
+
+    cookies {
+        forward = "none"
+      }
+    }
+  }
+
+
   price_class = var.price_class
 
   restrictions {

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -47,23 +47,3 @@ variable "aws_region" {
 variable "url" {}
 variable "certificate_arn" {}
 variable "namespace" {}
-
-output "website_domain" {
-  value = module.static_website_example.s3_bucket_website_domain
-}
-
-output "website_endpoint" {
-  value = module.static_website_example.s3_bucket_website_endpoint
-}
-
-output "website_hosted_id" {
-  value = module.static_website_example.s3_bucket_hosted_id
-}
-
-output "cloudfront_url" {
-  value = module.static_website_example.cloudfront_url
-}
-
-output "cloudfront_hosted_zone" {
-  value = module.static_website_example.cloudfront_hosted_zone
-}

--- a/examples/default/outputs.tf
+++ b/examples/default/outputs.tf
@@ -1,0 +1,19 @@
+output "bucket_domain" {
+  value = module.static_website_example.s3_bucket_domain_name
+}
+
+output "website_endpoint" {
+  value = module.static_website_example.s3_bucket_website_endpoint
+}
+
+output "website_hosted_id" {
+  value = module.static_website_example.s3_bucket_hosted_id
+}
+
+output "cloudfront_url" {
+  value = module.static_website_example.cloudfront_url
+}
+
+output "cloudfront_hosted_zone" {
+  value = module.static_website_example.cloudfront_hosted_zone
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,24 +1,24 @@
-output "s3_bucket_website_domain" {
-  description = "The domain of the s3 web site bucket."
-  value       = element(concat(aws_s3_bucket.static_website.*.website_domain, list("")), 0)
+output "s3_bucket_domain_name" {
+  description = "The regional domain of the s3 web site bucket."
+  value       = aws_s3_bucket.static_website.bucket_regional_domain_name
 }
 
 output "s3_bucket_website_endpoint" {
   description = "The endpoint of the s3 web site bucket."
-  value       = element(concat(aws_s3_bucket.static_website.*.website_endpoint, list("")), 0)
+  value       = aws_s3_bucket.static_website.website_endpoint
 }
 
 output "s3_bucket_hosted_id" {
   description = "The hosted_id s3 web site bucket."
-  value       = element(concat(aws_s3_bucket.static_website.*.hosted_zone_id, list("")), 0)
+  value       = aws_s3_bucket.static_website.hosted_zone_id
 }
 
 output "cloudfront_url" {
   description = "The URL for the Cloudfront Distribution - used to set the alias for the custom domain."
-  value       = element(concat(aws_cloudfront_distribution.cdn.*.domain_name, list("")), 0)
+  value       = aws_cloudfront_distribution.cdn.domain_name
 }
 
 output "cloudfront_hosted_zone" {
   description = "The hosted zone id of the Cloudfront Distribution"
-  value       = element(concat(aws_cloudfront_distribution.cdn.*.hosted_zone_id, list("")), 0)
+  value       = aws_cloudfront_distribution.cdn.hosted_zone_id
 }


### PR DESCRIPTION
Allows instance refresh of index.html and config.json files when new release versions have been deployed. Requests to index.html and config.json will be served straight from the S3 origin.

This can be confirmed by examining the `x-cache` response header which should have a value of `Miss from cloudfront`

When applying this version of the module to an existing version, the files will not update until the cache has been propagated across all edge locations. this will take ~15 minutes. Once propagated any new versions of the index.html and the config.json will update instantly.